### PR TITLE
Allow refreshing cached SMART attributes without reopening the disk

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,25 @@ impl Disk {
         }
     }
 
+    /// Refreshes cached SMART attribute values.
+    ///
+    /// SMART attribute values are read once in Disk::new and cached. Methods such as
+    /// `get_temperature` use these cached values and do not access the disk. Call this method to
+    /// refresh the cached values.
+    ///
+    /// Note: calling this method might cause the disk to wake up from sleep. Consider checking if
+    /// the disk is asleep using `check_sleep_mode` before calling this method to avoid this.
+    pub fn refresh_smart_data(&mut self) -> Result<(), Errno> {
+        unsafe {
+            let ret = sk_disk_smart_read_data(self.skdisk);
+            if ret < 0 {
+                let fail = nix::errno::errno();
+                return Err(Errno::from_i32(fail));
+            }
+            Ok(())
+        }
+    }
+
     /// Returns a u64 representing the size of the disk in bytes.
     pub fn get_disk_size(&mut self) -> Result<u64, Errno> {
         unsafe {


### PR DESCRIPTION
My use case for this is a very simple monitoring daemon, which opens the disks it monitors once at startup. After adding this code, I started seeing temperature changes.

I haven't dug through libatasmart to confirm what is and is not cached, but it looks like bad sectors are also cached. Maybe that needs to come with an additional warning, as it's not immediately obvious the data is stale (seeing exactly the same temperature each time is surprising, seeing zero bad sectors every time would not be).