### PR TITLE
Re-export the nix crate, which we use in our public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ use libatasmart_sys::*;
 use nix::errno::Errno;
 use std::{ffi::CString, path::{Path, PathBuf}, mem::MaybeUninit};
 pub use libatasmart_sys::SkSmartSelfTest;
+pub extern crate nix;
 
 /*
 #[cfg(test)]


### PR DESCRIPTION
I think this is right, but I'm pretty new to Rust and not sure if `pub use nix::errno` would be better. I found https://github.com/rust-lang/api-guidelines/issues/176 which seems to be heading towards recommending what I have.

I haven't actually needed the error constants (like ENODEV) yet, but I did need the Errno type in my own code so that I could include it as reason in my own error type. It looks like you can currently only do this by adding your own dependency on nix, which is inconvenient because its version must be kept in sync with libatasmart's, or the code will stop compiling.