### PR TITLE
Remove unused enum Err

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,5 @@ keywords = ["storage"]
 edition = '2018'
 
 [dependencies]
-derive-error = "0.0"
 libatasmart-sys = "~0.1"
 nix = "~0.17"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 //! more reliable and also a lot more performant!
 //!
 
-use derive_error as de;
 use libatasmart_sys::*;
 use nix::errno::Errno;
 use std::{ffi::CString, path::{Path, PathBuf}, mem::MaybeUninit};
@@ -36,13 +35,6 @@ mod tests {
         let ret = disk.dump();
     }
     */
-}
-
-#[derive(Debug, de::Error)]
-pub enum Err {
-    #[error(message_embedded, non_std, no_from)]
-    Err(String),
-    Io(std::io::Error),
 }
 
 /// Our ata smart disk


### PR DESCRIPTION
This was introduced in commit 60e883f35106de719f3324edf958d66cbea8f41c,
which is exported but it looks like it was never used.

Dropping the unused enum lets us drop the derive-error dependency,
which in turn pulls in older versions of other crates.