### PR TITLE
added identify_parse function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,9 +306,15 @@ impl Disk {
                     let fail = nix::errno::errno();
                     return Err(Errno::from_i32(fail));
                 }
-                let model = CStr::from_ptr((*parsed_data_pointer).model.as_ptr()).to_str().unwrap();
-                let firmware = CStr::from_ptr((*parsed_data_pointer).firmware.as_ptr()).to_str().unwrap();
-                let serial = CStr::from_ptr((*parsed_data_pointer).serial.as_ptr()).to_str().unwrap();
+                let model = CStr::from_ptr((*parsed_data_pointer).model.as_ptr()).to_str().unwrap_or_else(|_error|{
+                    ""
+                });
+                let firmware = CStr::from_ptr((*parsed_data_pointer).firmware.as_ptr()).to_str().unwrap_or_else(|_error|{
+                    ""
+                });
+                let serial = CStr::from_ptr((*parsed_data_pointer).serial.as_ptr()).to_str().unwrap_or_else(|_error|{
+                    ""
+                });
                 
                 let parsed_data: IdentifyParsedData = IdentifyParsedData {
                     serial: String::from(serial),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,7 +294,8 @@ impl Disk {
         }
     }
 
-    // Get the model, firmware, and serial of the disk as a IdentifyParsedDatastruct
+    /// Get the model, firmware, and serial of the disk as a IdentifyParsedDatastruct
+    /// If Errno::EINVAL gets returned there is a problem with the C string parser
     pub fn identify_parse(&mut self) -> Result<IdentifyParsedData, Errno> {
         let mut available: SkBool = 0;
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,15 +306,9 @@ impl Disk {
                     let fail = nix::errno::errno();
                     return Err(Errno::from_i32(fail));
                 }
-                let model = CStr::from_ptr((*parsed_data_pointer).model.as_ptr()).to_str().unwrap_or_else(|_error|{
-                    ""
-                });
-                let firmware = CStr::from_ptr((*parsed_data_pointer).firmware.as_ptr()).to_str().unwrap_or_else(|_error|{
-                    ""
-                });
-                let serial = CStr::from_ptr((*parsed_data_pointer).serial.as_ptr()).to_str().unwrap_or_else(|_error|{
-                    ""
-                });
+                let model = CStr::from_ptr((*parsed_data_pointer).model.as_ptr()).to_str().map_err(|_| Errno::EINVAL)?;
+                let firmware = CStr::from_ptr((*parsed_data_pointer).firmware.as_ptr()).to_str().map_err(|_| Errno::EINVAL)?;
+                let serial = CStr::from_ptr((*parsed_data_pointer).serial.as_ptr()).to_str().map_err(|_| Errno::EINVAL)?;
                 
                 let parsed_data: IdentifyParsedData = IdentifyParsedData {
                     serial: String::from(serial),


### PR DESCRIPTION
I converted the C struct in `identify_parse` to a Rust one to avoid C types in a main program.
I also added `pub` to ` fn parse_attributes` since it was creating a compiler warning and ever other function uses `pub`